### PR TITLE
[AIRFLOW-1009] Remove SQLOperator from Concepts page

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -110,7 +110,7 @@ Airflow provides operators for many common tasks, including:
 - ``PythonOperator`` - calls an arbitrary Python function
 - ``EmailOperator`` - sends an email
 - ``HTTPOperator`` - sends an HTTP request
-- ``SqlOperator`` - executes a SQL command
+- ``MySqlOperator``, ``SqliteOperator``, ``PostgresOperator``, ``MsSqlOperator``, ``OracleOperator``, ``JdbcOperator``, etc. - executes a SQL command
 - ``Sensor`` - waits for a certain time, file, database row, S3 key, etc...
 
 


### PR DESCRIPTION
Remove SQLOperator from Concepts page. Update with a sample list of database backend-specific operators, lile, MySqlOperator, SqliteOperator, PostgresOperator, MsSqlOperator, OracleOperator, JdbcOperator

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ AIRFLOW-1009] Remove SQLOperator from Concepts page
    - https://issues.apache.org/jira/browse/AIRFLOW-1009


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
As discussed in the dev list..
SQLOperator neither in the source code nor in the API Reference.
Although it is mentioned in Concepts page :
SqlOperator - executes a SQL command
https://github.com/apache/incubator-airflow/blob/master/docs/concepts.rst#operators
Should be updated with 
``MySqlOperator``, ``SqliteOperator``, ``PostgresOperator``, ``MsSqlOperator``, ``OracleOperator``, ``JdbcOperator``, etc. - executes a SQL command

### Tests
- [ ] Documentation only


