### PR TITLE
AIRFLOW-1012 - add run_as_script parameter

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -138,7 +138,7 @@ class DbApiHook(BaseHook):
         conn.close()
         return rows
 
-    def run(self, sql, autocommit=False, parameters=None):
+    def run(self, sql, autocommit=False, run_as_script=False, parameters=None):
         """
         Runs a command or a list of commands. Pass a list of sql
         statements to the sql parameter to get them to execute
@@ -150,12 +150,19 @@ class DbApiHook(BaseHook):
         :param autocommit: What to set the connection's autocommit setting to
             before executing the query.
         :type autocommit: bool
+        :param run_as_script: Split sql into individual statements
+        :type run_as_script: bool
         :param parameters: The parameters to render the SQL query with.
         :type parameters: mapping or iterable
         """
         conn = self.get_conn()
         if isinstance(sql, basestring):
-            sql = [sql]
+            if run_as_script:
+                sql = sql.split(';')    # split statements using ';'
+                if sql[-1].isspace():   # if ; was used for the last statement
+                        sql = sql[:-1]  # - don't execute empty statement
+            else:
+                sql = [sql]
 
         if self.supports_autocommit:
             self.set_autocommit(conn, autocommit)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

